### PR TITLE
Fix for session frequently being disposed before lock release

### DIFF
--- a/Consul/Consul.csproj
+++ b/Consul/Consul.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <VersionPrefix>0.7.2.6</VersionPrefix>
+    <VersionPrefix>0.7.2.7</VersionPrefix>
     <TargetFrameworks>netstandard1.3;net45</TargetFrameworks>
     <AssemblyName>Consul</AssemblyName>
     <PackageId>Consul</PackageId>

--- a/Consul/Lock.cs
+++ b/Consul/Lock.cs
@@ -362,8 +362,6 @@ namespace Consul
                     }
                     IsHeld = false;
 
-                    DisposeCancellationTokenSource();
-
                     var lockEnt = LockEntry(LockSession);
 
                     await _client.KV.Release(lockEnt, ct).ConfigureAwait(false);
@@ -371,6 +369,8 @@ namespace Consul
             }
             finally
             {
+                DisposeCancellationTokenSource();
+
                 if (_sessionRenewTask != null)
                 {
                     try


### PR DESCRIPTION
The cancellation source that provides tokens for the long running
session refresh task and the lock monitoring task is cancelled before
the KV release call, which can frequently cause session invalidation and
trigger the 15 second lock wait timeout (particularly in scenarios where
a lock is frequently released and re-acquired). Move the cancellation
into the finally block so that the session disposal happens after the
KV release.